### PR TITLE
Adding Monospace, Roboto and system-ui font options

### DIFF
--- a/dist/dist.js
+++ b/dist/dist.js
@@ -742,6 +742,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
       toolbar: [
       // [groupName, [list of button]]
       ['para', ['style']], ['style', ['bold', 'italic', 'underline', 'strikethrough', 'clear']], ['fontsize', ['fontsize', 'fontname']], ['color', ['color']], ['para', ['ul', 'ol', 'paragraph']], ['height', ['height']], ['insert', ['table', 'link', 'hr', 'picture', 'video']], ['misc', ['codeview', 'help']]],
+      fontNames: ['Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Helvetica Neue', 'Helvetica', 'Impact', 'Lucida Grande', 'Monospace', 'Roboto', 'system-ui', 'Tahoma', 'Times New Roman', 'Verdana'],
       callbacks: {
         onInit: function onInit() {},
         onImageUpload: function onImageUpload(files) {

--- a/src/main.js
+++ b/src/main.js
@@ -120,6 +120,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
         ['insert', ['table', 'link', 'hr', 'picture', 'video']],
         ['misc', ['codeview', 'help']]
       ],
+      fontNames: ['Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Helvetica Neue',
+        'Helvetica', 'Impact', 'Lucida Grande', 'Monospace', 'Roboto', 'system-ui', 'Tahoma',
+        'Times New Roman', 'Verdana'],
       callbacks: {
         onInit: function() {},
         onImageUpload: function (files) {


### PR DESCRIPTION
Due to how Summernote handles fonts, this includes all the default fonts Summernote tries to include and adds the following 3:
- Monospace
- Roboto
- system-ui
See original list from Summernote: [https://github.com/summernote/summernote/blob/develop/src/js/base/settings.js#L129](https://github.com/summernote/summernote/blob/develop/src/js/base/settings.js#L129)

They attempt to load them in the context (if you have them in your browser/system). The reason I found out about this was because my Linux installation had a different font selection than my Macbook one. So it only includes the ones you have in the dropdown.

This is in reference to our discussion: https://github.com/standardnotes/forum/issues/378#issuecomment-470591644