### PR TITLE
fix: tab key inserts tab space

### DIFF
--- a/dist/dist.js
+++ b/dist/dist.js
@@ -797,6 +797,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
       minHeight: null, // set minimum height of editor
       maxHeight: null, // set maximum height of editor
       focus: true, // set focus to editable area after initializing summernote
+      tabDisable: true, // set tab interaction to note only
       toolbar: [
       // [groupName, [list of button]]
       ['para', ['style']], ['style', ['bold', 'italic', 'underline', 'strikethrough', 'clear']], ['fontsize', ['fontsize', 'fontname']], ['color', ['color']], ['para', ['ul', 'ol', 'paragraph']], ['height', ['height']], ['insert', ['table', 'link', 'hr', 'picture', 'video']], ['misc', ['codeview', 'help']]],

--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,8 @@ document.addEventListener("DOMContentLoaded", function(event) {
       height: 500,                 // set editor height
       minHeight: null,             // set minimum height of editor
       maxHeight: null,             // set maximum height of editor
-      focus: true,                  // set focus to editable area after initializing summernote
+      focus: true,                 // set focus to editable area after initializing summernote
+      tabDisable: true,            // set tab interaction to note only
       toolbar: [
         // [groupName, [list of button]]
         ['para', ['style']],


### PR DESCRIPTION
Closes #23 

**Issue:**
Tab key does not insert tab space, rather, it cycles through UI controls.

**Summary of changes**:
Summernote has an initialization option to toggle the behaviour of the tab key. The option is now set to disable tabbing the UI.